### PR TITLE
Make `tribool` serializable and remove old forward declare

### DIFF
--- a/cflib/net/websocketservice.h
+++ b/cflib/net/websocketservice.h
@@ -15,8 +15,6 @@ namespace cflib { namespace util { class EVTimer; }}
 
 namespace cflib { namespace net {
 
-class ApiServer;
-
 class WebSocketService : public RequestHandler, public util::ThreadVerify
 {
 public:

--- a/cflib/serialize/tribool.h
+++ b/cflib/serialize/tribool.h
@@ -27,6 +27,13 @@ public:
 	quint8 toInt() const { return state_; }
 	static TriBool fromInt(quint8 state) { TriBool b; b.state_ = state; return b; }
 
+	template<typename T> void serialize(T & ser) const {
+		ser << state_;
+	}
+	template<typename T> void deserialize(T & ser) {
+		ser >> state_;
+	}
+
 private:
 	quint8 state_;
 };


### PR DESCRIPTION
This PR adds a `serialize` and `deserialize` to the `TriBool` type. It also removes an unused forward declare `ApiServer`.

I'm not sure if this is the right way to extend `TriBool`. I noticed compilation failures in a downstream project which used
`TriBool` and complained about missing serializer functionality.